### PR TITLE
Fix: Switch to restcountries v3 API and use common country name

### DIFF
--- a/scripts/init-countries.js
+++ b/scripts/init-countries.js
@@ -48,9 +48,9 @@ async function main () {
     try {
         const countryPromises = countries.data.map((country, index) => {
             const text = 'INSERT INTO country(id, country_id, name, code, region, subregion, lat, long) VALUES($1, $2, $3, $4, $5, $6, $7, $8)'
-            let code = country.alpha2Code
+            let code = country.cca2
             if (!code) {
-                code = country.alpha3Code
+                code = country.cca3
             }
 
             let lat, long = ''
@@ -62,8 +62,8 @@ async function main () {
             
             const region = country.region || "unknown region"
             const subregion = country.subregion || "unknown subregion"
-
-            return client.query(text, [index, index, country.name, code, region, subregion, lat, long]) 
+            let name = country.name["common"]
+            return client.query(text, [index, index, name, code, region, subregion, lat, long]) 
         })
     
         await Promise.all(countryPromises)
@@ -112,7 +112,7 @@ async function main () {
 }
 
 async function getCountries () {
-    return axios.get('https://restcountries.com/v2/all')
+    return axios.get('https://restcountries.com/v3/all')
 }
 
 async function getCities () {


### PR DESCRIPTION
**What's changed:**
- Switching from using official counties' names to common names introduced on the latest version of restcountries API.

**Related Issues:**
- https://github.com/threefoldtech/tfchain_graphql/issues/148

**Description:**

This is a temporary, easy workaround fix for the issue https://github.com/threefoldtech/tfchain_graphql/issues/148. 

However, although it should resolve the mismatch for the reported countries, it is important to note that this fix may not work for all countries as the process of joining data from different APIs based on country names is not reliable. 

To elaborate, in our squid processor, we fetch cities from the repository available at https://raw.githubusercontent.com/shivammathur/countrycity/master/data/geo.json and countries from the https://restcountries.com/ API. We then join these data based on the country name. Similarly, in the Gridproxy, we fetch node data from the chain and county data from GraphQL and join it based on the country name.

This process is not always accurate as there are often alternative spellings for country names. Hence, unless you are using the same data source, it's not guaranteed to find a match.

To properly resolve this issue, I suggest using the same API or a more unique identifier such as country code. However, this would require changes in different services.