### PR TITLE
Fix serviceContractCanceled mapping

### DIFF
--- a/src/mappings/serviceContracts.ts
+++ b/src/mappings/serviceContracts.ts
@@ -106,8 +106,18 @@ export async function serviceContractCanceled(
     ctx: Ctx,
     item: EventItem<'SmartContractModule.ServiceContractCanceled', { event: { args: true } }>,
 ) {
-    const serviceContractCanceledEvent = new SmartContractModuleServiceContractCanceledEvent(ctx, item.event).asV122
-
+    const SmartContractModuleServiceContractCanceled = new SmartContractModuleServiceContractCanceledEvent(ctx, item.event)
+    let serviceContractCanceledEvent
+    if (SmartContractModuleServiceContractCanceled.isV122) {
+        serviceContractCanceledEvent = SmartContractModuleServiceContractCanceled.asV122
+    } else if (SmartContractModuleServiceContractCanceled.isV147) {
+        serviceContractCanceledEvent = SmartContractModuleServiceContractCanceled.asV147
+    } else if (SmartContractModuleServiceContractCanceled.isV148) {
+        serviceContractCanceledEvent = SmartContractModuleServiceContractCanceled.asV148
+    }
+    if (!serviceContractCanceledEvent) {
+        return
+    }
     const savedServiceContract = await ctx.store.get(ServiceContract, { where: { serviceContractID: serviceContractCanceledEvent.serviceContractId } })
 
     if (savedServiceContract) {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -601,6 +601,36 @@ export class SmartContractModuleServiceContractCanceledEvent {
         assert(this.isV122)
         return this._chain.decodeEvent(this.event)
     }
+
+    /**
+     * A Service contract is canceled
+     */
+    get isV147(): boolean {
+        return this._chain.getEventHash('SmartContractModule.ServiceContractCanceled') === 'c1b811383f4c46c79d9252b8f6dbe81b61a54f6c5220f0e27c08afc4e3bb7e05'
+    }
+
+    /**
+     * A Service contract is canceled
+     */
+    get asV147(): {serviceContractId: bigint, cause: v147.Cause} {
+        assert(this.isV147)
+        return this._chain.decodeEvent(this.event)
+    }
+
+    /**
+     * A Service contract is canceled
+     */
+    get isV148(): boolean {
+        return this._chain.getEventHash('SmartContractModule.ServiceContractCanceled') === '81b199eeeb3cc1475f804bd214247b4b1139b8030c6317968be94deb438b6e07'
+    }
+
+    /**
+     * A Service contract is canceled
+     */
+    get asV148(): {serviceContractId: bigint, cause: v148.Cause} {
+        assert(this.isV148)
+        return this._chain.decodeEvent(this.event)
+    }
 }
 
 export class SmartContractModuleServiceContractCreatedEvent {

--- a/typegen/typegen.json
+++ b/typegen/typegen.json
@@ -30,6 +30,17 @@
     "SmartContractModule.NameContractCanceled",
     "SmartContractModule.ContractBilled",
     "SmartContractModule.UpdatedUsedResources",
-    "SmartContractModule.NodeExtraFeeSet"
+    "SmartContractModule.NodeExtraFeeSet",
+    "SmartContractModule.ServiceContractCreated",
+    "SmartContractModule.ServiceContractMetadataSet",
+    "SmartContractModule.ServiceContractFeesSet",
+    "SmartContractModule.ServiceContractApproved",
+    "SmartContractModule.ServiceContractCanceled",
+    "SmartContractModule.ServiceContractBilled",
+    "SmartContractModule.RentContractCanceled",
+    "SmartContractModule.ContractGracePeriodStarted",
+    "SmartContractModule.ContractGracePeriodEnded",
+    "SmartContractModule.SolutionProviderCreated",
+    "SmartContractModule.SolutionProviderApproved"
   ]
 }


### PR DESCRIPTION
- Add service contract related events to `typegen.json`
- add updated event `serviceContractCanceled` to the main events definitions
- update processor event mapping 