### PR TITLE
Fixing pricing-policy ID 0 for some farms

### DIFF
--- a/src/mappings/farms.ts
+++ b/src/mappings/farms.ts
@@ -110,7 +110,9 @@ export async function farmUpdated(
   savedFarm.gridVersion = farmUpdatedEventParsed.version
   savedFarm.name = validateString(ctx, farmUpdatedEventParsed.name.toString())
   savedFarm.twinID = farmUpdatedEventParsed.twinId
-  savedFarm.pricingPolicyID = farmUpdatedEventParsed.pricingPolicyId
+  // reason for commented the below line is that update_farm on-chain isnever meant to change the pricing policy attached to a farm
+  // see here https://github.com/threefoldtech/tfchain_graphql/issues/96#issuecomment-2068325597
+  // savedFarm.pricingPolicyID = farmUpdatedEventParsed.pricingPolicyId
   savedFarm.certification = certification
 
   let eventPublicIPs = farmUpdatedEventParsed.publicIps


### PR DESCRIPTION
There was an issue of data inconsistency caused by an old implementation of the update farm extrinsic. This allowed users to mess up with their farms' pricing policy. Later, a storage migration reset all the farms' pricing policy to the default one. To solve this issue, it is proposed that the value of pricing policy ID on all farmUpdated events should be ignored since it was never meant to be altered.

For context see here
https://github.com/threefoldtech/tfchain_graphql/issues/96#issue-1603754480

- Fixes #96, #160 