### PR TITLE
fix: matching ip address with gateway

### DIFF
--- a/src/mappings/farms.ts
+++ b/src/mappings/farms.ts
@@ -92,7 +92,7 @@ function checkIPs(ctx: Ctx, ipv4_a: string, ipv4_b: string): boolean {
         const ip_b = ipaddr.parse(ipv4_b);
 
         // check if both IP addresses are the same
-        if (ip_a[0] == ip_b) {
+        if (ip_a[0].toString() == ip_b.toString()) {
             ctx.log.warn(`The IP addresses are the same. Public IP: ${ipv4_a}, Gateway: ${ipv4_b}`);
             return false;
         }


### PR DESCRIPTION
What's changed:
- Checking whether both the IP address and gateway address are the same (as part of the previously added IP validation rules) didn't function correctly in the previous release. This patch ensures that it runs correctly.

Logs show that this validation at work:

```json
{"level":3,"time":1716915040735,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/16, Gateway: 1.1.1.1"}
{"level":3,"time":1716915097216,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 10.1.2.4/25, Gateway: 10.1.2.4"}
{"level":3,"time":1716915104602,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 192.168.0.0/16, Gateway: 192.168.0.0"}
{"level":3,"time":1716915118340,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/24, Gateway: 1.1.1.1"}
{"level":3,"time":1716915118360,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/24, Gateway: 1.1.1.1"}
{"level":3,"time":1716915123167,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 0.0.0.201/16, Gateway: 0.0.0.201"}
{"level":3,"time":1716915128148,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/24, Gateway: 1.1.1.1"}
{"level":3,"time":1716915128154,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/24, Gateway: 1.1.1.1"}
{"level":3,"time":1716915128160,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/24, Gateway: 1.1.1.1"}
{"level":3,"time":1716915128169,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/24, Gateway: 1.1.1.1"}
{"level":3,"time":1716915128186,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/24, Gateway: 1.1.1.1"}
{"level":3,"time":1716915131097,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 142.12.14.1/24, Gateway: 142.12.14.1"}
{"level":3,"time":1716915138956,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/16, Gateway: 1.1.1.1"}
{"level":3,"time":1716915154461,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.0.0.1/32, Gateway: 1.0.0.1"}
{"level":3,"time":1716915169086,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.0.0.1/32, Gateway: 1.0.0.1"}
{"level":3,"time":1716915183304,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 121.64.32.15/16, Gateway: 121.64.32.15"}
{"level":3,"time":1716915183624,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 121.64.32.15/16, Gateway: 121.64.32.15"}
{"level":3,"time":1716915215309,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/16, Gateway: 1.1.1.1"}
{"level":3,"time":1716915254692,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 142.12.14.1/24, Gateway: 142.12.14.1"}
{"level":3,"time":1716915254692,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/16, Gateway: 1.1.1.1"}
{"level":3,"time":1716915254696,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 142.12.14.1/24, Gateway: 142.12.14.1"}
{"level":3,"time":1716915254702,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 142.12.14.1/24, Gateway: 142.12.14.1"}
{"level":3,"time":1716915254703,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/16, Gateway: 1.1.1.1"}
{"level":3,"time":1716915254707,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 142.12.14.1/24, Gateway: 142.12.14.1"}
{"level":3,"time":1716915254707,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/16, Gateway: 1.1.1.1"}
{"level":3,"time":1716915254766,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 142.12.14.1/24, Gateway: 142.12.14.1"}
{"level":3,"time":1716915254767,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/16, Gateway: 1.1.1.1"}
{"level":3,"time":1716915254812,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 142.12.14.1/24, Gateway: 142.12.14.1"}
{"level":3,"time":1716915254812,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/16, Gateway: 1.1.1.1"}
{"level":3,"time":1716915254827,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 142.12.14.1/24, Gateway: 142.12.14.1"}
{"level":3,"time":1716915254827,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 1.1.1.1/16, Gateway: 1.1.1.1"}
{"level":3,"time":1716915254905,"ns":"sqd:processor:mapping","msg":"The IP addresses are the same. Public IP: 142.12.14.1/24, Gateway: 142.12.14.1"}
```