### PR TITLE
fix: resolve logic issues in contract and farm mapping handlers

### DIFF
--- a/src/mappings/contracts.ts
+++ b/src/mappings/contracts.ts
@@ -199,6 +199,21 @@ export async function contractUpdated(
     if (SavedNameContract) {
         await updateNameContract(ctx, contractEvent, SavedNameContract, ctx.store)
     }
+
+    const SavedRentContract = await ctx.store.get(RentContract, { where: { contractID: contractEvent.contractId } })
+    if (SavedRentContract) {
+        await updateRentContract(ctx, contractEvent, SavedRentContract, ctx.store)
+    }
+}
+
+function parseContractState(kind: string): ContractState {
+    switch (kind) {
+        case 'Created': return ContractState.Created
+        case 'Deleted': return ContractState.Deleted
+        case 'GracePeriod': return ContractState.GracePeriod
+        case 'OutOfFunds': return ContractState.OutOfFunds
+        default: return ContractState.OutOfFunds
+    }
 }
 
 async function updateNodeContract(ctx: Ctx, ctr: any, contract: NodeContract, store: Store) {
@@ -215,16 +230,10 @@ async function updateNodeContract(ctx: Ctx, ctr: any, contract: NodeContract, st
     contract.deploymentData = validateString(ctx, parsedNodeContract.deploymentData.toString())
     contract.deploymentHash = validateString(ctx, parsedNodeContract.deploymentHash.toString())
 
-    let state = ContractState.OutOfFunds
-    switch (ctr.state.__kind) {
-        case 'Created':
-            state = ContractState.Created
-            break
-        case 'Deleted':
-            state = ContractState.Deleted
-            break
+    contract.state = parseContractState(ctr.state.__kind)
+    if (ctr.solutionProviderId !== undefined) {
+        contract.solutionProviderID = Number(ctr.solutionProviderId) || 0
     }
-    contract.state = state
     await store.save<NodeContract>(contract)
 }
 
@@ -238,17 +247,28 @@ async function updateNameContract(ctx: Ctx, ctr: any, contract: NameContract, st
     contract.twinID = ctr.twinId
     contract.name = validateString(ctx, parsedNameContract.name.toString())
 
-    let state = ContractState.OutOfFunds
-    switch (ctr.state.__kind) {
-        case 'Created':
-            state = ContractState.Created
-            break
-        case 'Deleted':
-            state = ContractState.Deleted
-            break
+    contract.state = parseContractState(ctr.state.__kind)
+    if (ctr.solutionProviderId !== undefined) {
+        contract.solutionProviderID = Number(ctr.solutionProviderId) || 0
     }
-    contract.state = state
     await store.save<NameContract>(contract)
+}
+
+async function updateRentContract(ctx: Ctx, ctr: any, contract: RentContract, store: Store) {
+    if (ctr.contractType.__kind !== "RentContract") return
+
+    const parsedRentContract = ctr.contractType.value
+
+    contract.contractID = ctr.contractId
+    contract.gridVersion = ctr.version
+    contract.twinID = ctr.twinId
+    contract.nodeID = parsedRentContract.nodeId
+
+    contract.state = parseContractState(ctr.state.__kind)
+    if (ctr.solutionProviderId !== undefined) {
+        contract.solutionProviderID = Number(ctr.solutionProviderId) || 0
+    }
+    await store.save<RentContract>(contract)
 }
 
 export async function nodeContractCanceled(
@@ -272,10 +292,12 @@ export async function nodeContractCanceled(
     savedContract.state = ContractState.Deleted
     await ctx.store.save<NodeContract>(savedContract)
 
-    const savedPublicIP = await ctx.store.get(PublicIp, { where: { contractId: contractID }, relations: { farm: true } })
-    if (savedPublicIP) {
-        savedPublicIP.contractId = BigInt(0)
-        await ctx.store.save<PublicIp>(savedPublicIP)
+    const savedPublicIPs = await ctx.store.find(PublicIp, { where: { contractId: contractID }, relations: { farm: true } })
+    for (const ip of savedPublicIPs) {
+        ip.contractId = BigInt(0)
+    }
+    if (savedPublicIPs.length > 0) {
+        await ctx.store.save(savedPublicIPs)
     }
 }
 

--- a/src/mappings/farms.ts
+++ b/src/mappings/farms.ts
@@ -204,6 +204,10 @@ export async function farmUpdated(
         }
     }
 
+    if ('dedicatedFarm' in farmUpdatedEventParsed) {
+        savedFarm.dedicatedFarm = (farmUpdatedEventParsed as any).dedicatedFarm
+    }
+
     await ctx.store.save<Farm>(savedFarm)
 
     const publicIPsOfFarm = await ctx.store.find<PublicIp>(PublicIp, { where: { farm: { id: savedFarm.id } }, relations: { farm: true } })
@@ -214,12 +218,6 @@ export async function farmUpdated(
             ctx.log.debug({ eventName: item.name, ip: ip.ip.toString() }, `PublicIP: ${ip.ip.toString()} in farm: ${savedFarm.farmID} removed from publicIPs`);
         }
     }
-
-    let farm = item.event.args as Farm
-    if (farm.dedicatedFarm) {
-        savedFarm.dedicatedFarm = farm.dedicatedFarm
-    }
-    await ctx.store.save<Farm>(savedFarm)
 
 }
 


### PR DESCRIPTION
## Summary

Fixes 4 logic issues (L1–L4) identified during the mapping code audit (fixes #210). These are pre-existing bugs in the hand-maintained mapping handlers, found alongside the data-loss bugs fixed in #209.

### L1: GracePeriod state silently mapped to OutOfFunds (LOW)
`updateNodeContract()` and `updateNameContract()` only handled `Created` and `Deleted` in their state switch, with `OutOfFunds` as the default. The `GracePeriod` `__kind` (present from spec v59+) fell through to the default. Extracted a shared `parseContractState()` helper that explicitly maps all 4 `__kind` variants across all spec versions.

### L2: Multi-IP contracts only freed first IP on cancellation (HIGH)
`nodeContractCanceled` used `ctx.store.get()` (returns single entity) instead of `ctx.store.find()` (returns array) when looking up PublicIPs by contractId. Contracts with multiple public IPs only had the first IP released; the rest were orphaned with stale contract references. Now uses `find()` and loops through all matching IPs.

### L3: contractUpdated ignored RentContract and solutionProviderID (LOW)
`contractUpdated` only looked up `NodeContract` and `NameContract` — `RentContract` updates were silently dropped. Additionally, none of the update helpers set `solutionProviderID` even though the v105+ event payload includes it. Added `updateRentContract()` handler and `solutionProviderID` updates to all three helpers.

### L4: Unsafe cast for dedicatedFarm in farmUpdated (MEDIUM)
`farmUpdated` cast raw event args to the `Farm` DB model (`item.event.args as Farm`) to read `dedicatedFarm`. This is type-unsafe and wrong for v9 events where the field doesn't exist (only v50+ have it). Replaced with version-aware access via the already-parsed typed event and removed the redundant second `ctx.store.save()` call.

## Files changed
- `src/mappings/contracts.ts` — L1, L2, L3
- `src/mappings/farms.ts` — L4

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify indexer re-sync produces correct contract states for GracePeriod contracts
- [ ] Verify multi-IP contract cancellation frees all IPs
- [ ] Verify RentContract updates are reflected after ContractUpdated events

