### PR TITLE
fix: read node certification from NodeStored event payload

### DIFF
--- a/src/mappings/nodes.ts
+++ b/src/mappings/nodes.ts
@@ -72,7 +72,14 @@ export async function nodeStored(
 
     newNode.created = Number(nodeEvent.created)
     newNode.farmingPolicyId = nodeEvent.farmingPolicyId
-    newNode.certification = NodeCertification.Diy
+    newNode.certification = NodeCertification.Diy // v9 default; overridden below for v28+
+
+    if (node.isV28) {
+        const nodeAsV28 = node.asV28
+        newNode.certification = nodeAsV28.certificationType
+            ? parseNodeCertification(nodeAsV28.certificationType.__kind.toString())
+            : NodeCertification.Diy
+    }
 
     const newLocation = new Location()
     newLocation.id = item.event.id
@@ -103,6 +110,9 @@ export async function nodeStored(
         newNode.secure = nodeAsV43.secureBoot ? true : false
         newNode.virtualized = nodeAsV43.virtualized ? true : false
         newNode.serialNumber = validateString(ctx, nodeAsV43.serialNumber.toString())
+        newNode.certification = nodeAsV43.certificationType
+            ? parseNodeCertification(nodeAsV43.certificationType.__kind.toString())
+            : NodeCertification.Diy
     }
 
     if (node.isV63 || node.isV105) {
@@ -120,6 +130,9 @@ export async function nodeStored(
         newNode.virtualized = nodeEvent.virtualized ? true : false
         newNode.serialNumber = validateString(ctx, nodeEvent.serialNumber.toString())
         newNode.connectionPrice = nodeEvent.connectionPrice
+        newNode.certification = nodeEvent.certification
+            ? parseNodeCertification(nodeEvent.certification.__kind.toString())
+            : NodeCertification.Diy
     }
 
     if (node.isV118) {
@@ -130,6 +143,9 @@ export async function nodeStored(
         newNode.virtualized = nodeEvent.virtualized ? true : false
         newNode.serialNumber = nodeEvent.serialNumber ? validateString(ctx, nodeEvent.serialNumber.toString()) : 'Unknown'
         newNode.connectionPrice = nodeEvent.connectionPrice
+        newNode.certification = nodeEvent.certification
+            ? parseNodeCertification(nodeEvent.certification.__kind.toString())
+            : NodeCertification.Diy
     }
 
     await ctx.store.save<Node>(newNode)


### PR DESCRIPTION
## Summary

Fixes #193 — inconsistent node certification between chain and GraphQL.

`nodeStored` hardcoded `certification = Diy` and never read the actual value from the `NodeStored` event payload. Since spec v107, `create_node` assigns certification from the farming policy (which can be `Certified`), but the processor ignored it.

### Root cause

On-chain, `_create_node` sets `new_node.certification = farming_policy.node_certification` and emits `NodeStored` with the full node struct. The processor received this event but always stored `Diy`. No `NodeCertificationSet` event is emitted on node creation (never has been, in any spec version), so there was no other path to capture the initial certification.

### Verification

All 26 affected devnet nodes are associated with farming policy 3 (`nodeCertification: Certified`), confirming the root cause.

### Fix

Read certification from the `NodeStored` event payload for each version that includes it:
- v9: no certification field → `Diy` default preserved (correct)
- v28/v43: reads `certificationType.__kind` via `parseNodeCertification`
- v63/v105: reads `certification.__kind` via `parseNodeCertification`
- v118: reads `certification.__kind` via `parseNodeCertification`

This matches the pattern already used in `nodeUpdated`.

### Regression safety

- Only one `isVxx` branch executes per event (mutually exclusive hash checks)
- The `Diy` default (line 75) is set before any version-specific block, so it's always overridden for v28+
- v9 nodes are unaffected — no certification field exists, default `Diy` is correct
- `nodeUpdated` and `nodeCertificationSet` handlers are unchanged
- `npm run build` passes

## Test plan
- [x] `npm run build` passes
- [x] Re-index devnet and verify the affected nodes now show `Certified`