### PR TITLE
docs: align documentation branding with Ledger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ version-bump:
 typegen:
 	npx squid-substrate-typegen typegen/typegen.json
 
-# Discover all specVersions from all TFChain networks (mainnet, testnet, qanet, devnet)
+# Discover all specVersions from all Ledger Chain networks (mainnet, testnet, qanet, devnet)
 typegen-seed:
 	./scripts/seed-versions.sh
 

--- a/docs/advanced-development.md
+++ b/docs/advanced-development.md
@@ -4,7 +4,7 @@ This document covers the internal architecture of the tfchain_graphql indexer/pr
 
 ## 1. Pre-V14 Metadata and the typesBundle
 
-Substrate runtime metadata comes in different versions. TFChain has two eras:
+Substrate runtime metadata comes in different versions. Ledger Chain has two eras:
 
 - **V12 (pre-V14)**: metadata is NOT self-describing for custom types. The `typesBundle.json` file provides type definitions that tell the decoder how to interpret SCALE-encoded data.
 - **V14+**: metadata is self-describing. All type information is embedded in the metadata itself. The typesBundle is not used.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,4 @@
-# Developing on TFChain GraphQL
+# Developing on Ledger GraphQL
 
 ## Install
 
@@ -9,7 +9,7 @@ npm run build
 
 ## Local Network
 
-### Run TFChain
+### Run Ledger Chain
 
 See https://github.com/threefoldtech/tfchain
 
@@ -23,7 +23,7 @@ docker network create tfgrid_bknd
 
 ### Run Indexer
 
-Check `indexer/.env` and adjust the websocket endpoint to your local TFChain address.
+Check `indexer/.env` and adjust the websocket endpoint to your local Ledger Chain address.
 
 ```bash
 cd indexer
@@ -36,7 +36,7 @@ Indexer services should now be started. Check if it's syncing properly by stream
 docker logs indexer-ingest-1 -f
 ```
 
-You should see TFChain blocks being processed:
+You should see Ledger Chain blocks being processed:
 
 ![Indexer logs](https://user-images.githubusercontent.com/73958772/209998096-3d5381d9-97ee-438d-824d-d92d997b42aa.png)
 
@@ -60,7 +60,7 @@ npm run db:up
 npm run process
 ```
 
-You should see TFChain blocks being processed by the processor:
+You should see Ledger Chain blocks being processed by the processor:
 
 ![Processor logs](https://user-images.githubusercontent.com/73958772/210000023-c575d91a-382e-4fdc-85b3-199a135b493f.png)
 
@@ -86,7 +86,7 @@ Now you can use the GraphQL playground at http://localhost:4000/graphql
 
 ## Adding New Runtime Versions
 
-When TFChain has a new spec version with type changes, see [typeChanges.md](./typeChanges.md) for the full workflow. The short version:
+When Ledger Chain has a new spec version with type changes, see [typeChanges.md](./typeChanges.md) for the full workflow. The short version:
 
 ```bash
 # Point at your local chain (or a remote network via WS_URL=wss://...)

--- a/docs/production.md
+++ b/docs/production.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- TFChain network WebSocket URL (e.g., `wss://tfchain.dev.grid.tf/ws`)
+- Ledger Chain network WebSocket URL (e.g., `wss://tfchain.dev.grid.tf/ws`)
 - Docker
 - Docker Compose
 
@@ -10,7 +10,7 @@
 
 The production stack has two independent layers:
 
-1. **Indexer (archive)** — ingests raw blocks from a TFChain node into CockroachDB. Provides a GraphQL gateway for the processor to query block data.
+1. **Indexer (archive)** — ingests raw blocks from a Ledger Chain node into CockroachDB. Provides a GraphQL gateway for the processor to query block data.
 2. **Processor + Query Node** — reads events from the indexer, maps them to domain entities (nodes, farms, contracts, etc.), stores in PostgreSQL, and serves the public GraphQL API.
 
 ## Run the Setup
@@ -53,7 +53,7 @@ Configure `indexer/.env`:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `WS_ENDPOINT` | TFChain node WebSocket URL | `ws://localhost:9944` |
+| `WS_ENDPOINT` | Ledger Chain node WebSocket URL | `ws://localhost:9944` |
 | `START_HEIGHT` | Block height to start ingesting from. `0` = genesis (full history). Set higher only for testing or partial deployments — the processor will miss events before this height. | `0` |
 
 ```bash
@@ -74,7 +74,7 @@ Configure `.env` in the project root:
 | `DB_PASS` | PostgreSQL password | `postgres` |
 | `DB_PORT` | PostgreSQL port | `5432` |
 | `INDEXER_ENDPOINT_URL` | Indexer GraphQL gateway URL. Use `http://gateway:8000/graphql` for Docker (shared network), `http://localhost:8888/graphql` for local dev | `http://gateway:8000/graphql` |
-| `WS_URL` | TFChain node WebSocket URL (used for RPC calls) | `wss://tfchain.dev.grid.tf/ws` |
+| `WS_URL` | Ledger Chain node WebSocket URL (used for RPC calls) | `wss://tfchain.dev.grid.tf/ws` |
 | `TYPEORM_LOGGING` | TypeORM log level | `error` |
 
 ```bash

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,4 +1,4 @@
-# TFChain GraphQL Documentation
+# Ledger GraphQL Documentation
 
 ## Development
 

--- a/docs/typeChanges.md
+++ b/docs/typeChanges.md
@@ -9,12 +9,12 @@ via the `tfchainVersions.jsonl` append-only log and Subsquid's typegen tool.
 ### Key concepts
 
 - **`typegen/tfchainVersions.jsonl`** is an append-only log of runtime metadata
-  from all TFChain networks. It is committed to git and is the single source of
+  from all Ledger Chain networks. It is committed to git and is the single source of
   truth for type generation. Never delete or recreate this file — only append.
 
 - **`typegen/typesBundle.json`** is a frozen historical artifact that helps the
   metadata explorer decode pre-V14 runtime metadata (specVersions before ~v100).
-  TFChain now uses Polkadot SDK v1.1.0 with V14+ self-describing metadata, so
+  Ledger Chain now uses Polkadot SDK v1.1.0 with V14+ self-describing metadata, so
   **this file does not need editing for new runtime versions**. See
   [Notes on typesBundle.json](#notes-on-typesbundlejson) below.
 
@@ -38,7 +38,7 @@ known hash. The hash is derived from the event's SCALE-encoded type structure.
 
 ### Network deployment order matters
 
-TFChain follows the deployment pipeline: **devnet → qanet → testnet → mainnet**.
+Ledger Chain follows the deployment pipeline: **devnet → qanet → testnet → mainnet**.
 The JSONL file should be seeded in this order so that typegen assigns version
 labels matching the earliest deployment. The `seed-versions.sh` script handles
 this automatically.
@@ -270,7 +270,7 @@ fully self-describing. The types bundle tells the metadata explorer and typegen
 how to decode those custom pallet types. Without it, the explorer can't read
 metadata from blocks at those old specVersions.
 
-**Why it's frozen:** TFChain upgraded to Polkadot SDK v1.1.0, which uses V14+
+**Why it's frozen:** Ledger Chain upgraded to Polkadot SDK v1.1.0, which uses V14+
 self-describing metadata. Any new specVersion includes a complete type registry
 in its metadata — no external bundle needed. The types bundle only matters for
 the old pre-V14 blocks, which will never change.

--- a/indexer/development.md
+++ b/indexer/development.md
@@ -2,7 +2,7 @@
 
 ## typesBundle.json
 
-The `typesBundle.json` file maps Substrate custom types for pre-V14 metadata (specVersions before ~v100). This file is **frozen** — TFChain now uses Polkadot SDK v1.1.0 with V14+ self-describing metadata, so new runtime versions do not require changes to this file.
+The `typesBundle.json` file maps Substrate custom types for pre-V14 metadata (specVersions before ~v100). This file is **frozen** — Ledger Chain now uses Polkadot SDK v1.1.0 with V14+ self-describing metadata, so new runtime versions do not require changes to this file.
 
 See [docs/typeChanges.md](../docs/typeChanges.md#notes-on-typesbundlejson) for details.
 

--- a/indexer/readme.md
+++ b/indexer/readme.md
@@ -19,7 +19,7 @@ START_HEIGHT=0
 
 | Variable | Description |
 |----------|-------------|
-| `WS_ENDPOINT` | TFChain node WebSocket URL. e.g., `wss://tfchain.dev.grid.tf` or `ws://localhost:9944` |
+| `WS_ENDPOINT` | Ledger Chain node WebSocket URL. e.g., `wss://tfchain.dev.grid.tf` or `ws://localhost:9944` |
 | `START_HEIGHT` | Block height to start ingesting from. `0` = genesis (full history). Setting this higher skips earlier blocks — the processor will miss any events before this height. Only use non-zero values for testing or partial deployments. |
 
 ## Docker Compose
@@ -41,7 +41,7 @@ docker compose down
 | Container | Image | Role |
 |-----------|-------|------|
 | cockroachdb | `cockroachdb/cockroach` | Database for storing raw indexed block data |
-| ingest | `subsquid/substrate-ingest` | Connects to the TFChain node and ingests blocks into the database |
+| ingest | `subsquid/substrate-ingest` | Connects to the Ledger Chain node and ingests blocks into the database |
 | gateway | `subsquid/substrate-gateway` | GraphQL gateway over ingested data — the processor queries this |
 | explorer | `subsquid/substrate-explorer` | Web UI to browse raw ingested data and check sync status |
 

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -13,7 +13,7 @@
 
 | Script | Description |
 |--------|-------------|
-| `seed-versions.sh` | Discover all specVersions from all TFChain networks (devnet, qanet, testnet, mainnet) and populate `typegen/tfchainVersions.jsonl`. Used for initial seeding or recovery. |
+| `seed-versions.sh` | Discover all specVersions from all Ledger Chain networks (devnet, qanet, testnet, mainnet) and populate `typegen/tfchainVersions.jsonl`. Used for initial seeding or recovery. |
 | `merge-versions.js` | Append-only merger for JSONL files. Merges new specVersions into the existing version log, sorted by specVersion. Used by `make typegen-add`. |
 
 ## Data Files

--- a/scripts/seed-versions.sh
+++ b/scripts/seed-versions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# seed-versions.sh — Discover all specVersions from TFChain networks
+# seed-versions.sh — Discover all specVersions from Ledger Chain networks
 #
 # Runs squid-substrate-metadata-explorer against each network and merges
 # discovered specVersions into the master tfchainVersions.jsonl file.
@@ -54,7 +54,7 @@ if [ ! -f "$MASTER" ]; then
     echo "Created empty master file: $MASTER"
 fi
 
-echo "=== TFChain specVersion Discovery ==="
+echo "=== Ledger Chain specVersion Discovery ==="
 echo "Master file: $MASTER"
 echo ""
 


### PR DESCRIPTION
Final branding pass after merging the stack (#207–#221). Renames product/chain references in `docs/*.md` and tooling comments from **TFChain** to **Ledger** (`TFChain GraphQL`→`Ledger GraphQL`, chain `TFChain`→`Ledger Chain`), matching despiegk's README rebrand and the repo rename to `ledger_graphql`.

Technical references are intentionally **preserved**: `tfchain.grid.tf` endpoints, the `tfchainVersions.jsonl` filename, `github.com/threefoldtech/tfchain` links, helm release names.

10 files, comments/markdown only — no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)