### PR TITLE
fix: use named volumes for indexer and processor databases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "127.0.0.1:${DB_PORT}:5432"
     volumes:
-      - /var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
@@ -48,3 +48,6 @@ services:
       - 4000:4000
     depends_on:
       - db
+
+volumes:
+  postgres-data:

--- a/indexer/docker-compose.yml
+++ b/indexer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "127.0.0.1:8080:8080"
     command: start-single-node --insecure
     volumes:
-      - /cockroach/cockroach-data
+      - cockroach-data:/cockroach/cockroach-data
 
   cockroachdb-init:
     depends_on:
@@ -75,3 +75,6 @@ services:
       DB_USER: "root"
     ports:
       - "4444:3000"
+
+volumes:
+  cockroach-data:


### PR DESCRIPTION
## Problem
Both compose stacks store database data on **anonymous volumes**:
- `indexer/docker-compose.yml`: `cockroachdb` → `- /cockroach/cockroach-data`
- `docker-compose.yml`: `db` (postgres) → `- /var/lib/postgresql/data`

Anonymous volumes are bound to a specific container. A service **rename or recreate** (e.g. the recent `db`→`cockroachdb` rename in #218) orphans the old volume and brings the service up with **empty data**, forcing a full re-ingest (archive) or resync (processor).

## Fix
Switch both databases to **named volumes** (`cockroach-data`, `postgres-data`) declared at the top level, so data persists across renames/recreations.

Validated with `docker compose config` (both stacks render valid; volumes resolve to `indexer_cockroach-data` / `<project>_postgres-data`).

> Note: the first switch from anonymous→named won't auto-migrate existing data (different volume); it removes the footgun going forward. Existing archive data can be migrated manually or re-ingested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)