### PR TITLE
fix: remove unused --typesBundle flag from seed-versions.sh

### DIFF
--- a/scripts/seed-versions.sh
+++ b/scripts/seed-versions.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 MASTER="$REPO_DIR/typegen/tfchainVersions.jsonl"
-TYPES_BUNDLE="$REPO_DIR/typegen/typesBundle.json"
 TMP_DIR=$(mktemp -d)
 
 # Network endpoints
@@ -34,12 +33,6 @@ cleanup() {
     rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
-
-if [ ! -f "$TYPES_BUNDLE" ]; then
-    echo "Error: typesBundle.json not found at $TYPES_BUNDLE"
-    echo "Restore it from indexer/typesBundle.json first."
-    exit 1
-fi
 
 # Determine which networks to scan
 if [ $# -gt 0 ]; then
@@ -72,7 +65,6 @@ for network in $SCAN_NETWORKS; do
 
     if npx squid-substrate-metadata-explorer \
         --chain "$endpoint" \
-        --typesBundle "$TYPES_BUNDLE" \
         --out "$outfile" 2>&1; then
 
         if [ -f "$outfile" ] && [ -s "$outfile" ]; then


### PR DESCRIPTION
## Problem
`make typegen-seed` (and `./scripts/seed-versions.sh`) fails with the pinned `@subsquid/substrate-metadata-explorer@1.1.2`, which rejects `--typesBundle` (`error: unknown option '--typesBundle'`). The script masks this as a per-network *connection* warning and finishes having discovered **0 versions** — so the documented reseed/recovery path silently does nothing.

## Why removing the flag is the right fix
The flag was never needed. The explorer just fetches **raw runtime metadata blobs** over `--chain`; the types bundle is a **typegen-side** concern (decoding pre-V14 custom types), not required to *capture* metadata.

Verified: bundle-free explorer output is **byte-identical to the committed `tfchainVersions.jsonl`** for all 62 devnet versions, including pre-V14 (v49–v67).

## Change
- Remove `--typesBundle "$TYPES_BUNDLE"` from the explorer call.
- Remove the now-orphaned `TYPES_BUNDLE` variable and its existence-check guard (only existed to support the flag).
- Keeps `--chain` → reseeds from the canonical chain RPC, **no dependency on the archive**.

Note: the `--chain` walk is slow over public RPC (~5–15 min/network) — acceptable for a rare recovery operation; the script imposes no timeout and runs to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)