### PR TITLE
fix(ci): pin container image names instead of deriving them from the repo

### DIFF
--- a/.github/workflows/publish_container_images.yml
+++ b/.github/workflows/publish_container_images.yml
@@ -26,7 +26,14 @@ jobs:
         id: metaprocessor
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}_processor
+          # Pinned rather than derived from the github.repository context. Container
+          # packages are scoped to the organisation and named at push time, so they
+          # are not renamed or redirected when a repository is renamed. Interpolating
+          # the repository name meant this repo's rename would have silently started
+          # publishing to a brand new, empty package while every chart and compose
+          # file kept pulling the existing one — a release that changes nothing.
+          # The tfchain workflows pin their image names for the same reason.
+          images: ghcr.io/threefoldtech/tfchain_graphql_processor
           tags: |
             type=semver,pattern={{version}}
 
@@ -42,7 +49,8 @@ jobs:
         id: metaquerynode
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}_query-node
+          # Pinned for the same reason as the processor image above.
+          images: ghcr.io/threefoldtech/tfchain_graphql_query-node
           tags: |
             type=semver,pattern={{version}}
 


### PR DESCRIPTION
Prerequisite for the next release. Without this, tagging would publish images that nothing pulls.

## The problem

`publish_container_images.yml` derived its image names from the `github.repository` context:

```yaml
images: ghcr.io/${{ github.repository }}_processor
images: ghcr.io/${{ github.repository }}_query-node
```

Container packages are scoped to the **organisation** and named at **push time** — per GitHub's docs they are "scoped to accounts or organizations, not tied to repositories by default." A repository rename redirects git, web, issues, wikis and stars; it does **not** rename or redirect packages, and there is no facility to rename a package at all.

So after this repo's rename, the next release would have pushed to `ledger_graphql_{processor,query-node}` — brand new, empty packages — while every consumer kept pulling the old ones:

```
processor-chart/values.yaml:9   ghcr.io/threefoldtech/tfchain_graphql_processor
processor-chart/values.yaml:13  ghcr.io/threefoldtech/tfchain_graphql_query-node
docker-compose.yml:20           ghcr.io/threefoldtech/tfchain_graphql_processor:latest
docker-compose.yml:38           ghcr.io/threefoldtech/tfchain_graphql_query-node:latest
```

Verified against the registry:

```
tfchain_graphql_processor    HTTP 200   29 tags, latest 2.12.3   (live, public)
tfchain_graphql_query-node   HTTP 200   29 tags, latest 2.12.3   (live, public)
ledger_graphql_processor     HTTP 403   DENIED  (org API: 404 "Package not found")
ledger_graphql_query-node    HTTP 403   DENIED  (org API: 404 "Package not found")
```

The release would have looked successful and changed nothing for any deployment. The failure mode is *absence of updates*, not an error, so it would likely have gone unnoticed for a while.

## The fix

Pins both names to what consumers already reference, which is also how the tfchain workflows have always declared theirs — `ghcr.io/threefoldtech/tfchain_activation_service`, `..._stellar_bridge`, `.../tfchain` are all hardcoded, so that repo's rename to `ledger_chain` caused no such problem.

These were the only two uses of `github.repository` in any workflow here.

## Not done here

Renaming the images to match the rebrand is still available, but it is a breaking change — every deployment must update its image reference or silently stop receiving updates — so it belongs in a deliberate change that updates the charts and compose files at the same time, not as a side effect of a repo rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YKJm3zuWdSepriT9KL9zy