### PR TITLE
Bump version to 2.13.0

### DIFF
--- a/indexer/chart/Chart.yaml
+++ b/indexer/chart/Chart.yaml
@@ -2,4 +2,4 @@ name: tfchainindexer
 description: Helm Chart for the tfchain hydra indexer
 version: 2.7.8
 apiVersion: v2
-appVersion: '2.12.3'
+appVersion: '2.13.0'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql_tfgrid",
-  "version": "2.12.3",
+  "version": "2.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql_tfgrid",
-      "version": "2.12.3",
+      "version": "2.13.0",
       "license": "ISC",
       "dependencies": {
         "@encointer/util": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql_tfgrid",
   "private": "true",
-  "version": "2.12.3",
+  "version": "2.13.0",
   "description": "GraphQL server and Substrate indexer. Generated with ♥ by Hydra-CLI",
   "author": "",
   "license": "ISC",

--- a/processor-chart/Chart.yaml
+++ b/processor-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tfchain-processor
 description: A chart for the tfchain graphql processor and query node
 version: 1.0.6
-appVersion: '2.12.3'
+appVersion: '2.13.0'


### PR DESCRIPTION
First release since v2.12.3 (2025-10-02). Version bump only.

## Release contents

37 commits since v2.12.3. Four are indexing-correctness fixes that have been sitting unreleased:

- `fix: resolve data loss bugs in farm IP, node interface, and contract mapping handlers`
- `fix: resolve logic issues in contract and farm mapping handlers`
- `fix: read node certification from NodeStored event payload`
- `fix: patch dedicatedFarm field for pre-V14 Farm event decoding`

Plus 25 database indexes with a matching migration (`db/migrations/1775123913074-Data.js` — 25 `CREATE INDEX`, 25 `DROP INDEX`, nothing destructive; verified against the 25 `@index` additions in `schema.graphql`), typegen automation via the append-only version log, npm standardization, named volumes for the databases, and the docs/LICENSE rebrand.

Minor rather than patch: there is a `feat:` and a `perf:` alongside the fixes.

## ⚠️ A full processor resync is required

All four fixes are in mapping handlers — they change how events become entities. Rows already written by the buggy handlers are **not** retroactively corrected. Without a resync you end up with a database that is correct going forward and wrong historically, which is harder to reason about than being consistently wrong.

Related: the 25 new indexes are plain `CREATE INDEX`, not `CONCURRENTLY`, so on a large table they would take `ACCESS EXCLUSIVE` locks and stall the processor and API. If you are resyncing anyway they land on an empty database and this stops mattering.

This repo's release description is written by hand — unlike tfchain, there is no changelog-generating workflow — so the resync requirement needs to be carried into the release notes deliberately or it will not appear anywhere an operator looks.

## Scope

```
package.json                2.12.3 -> 2.13.0
package-lock.json           .version and .packages[""].version 2.12.3 -> 2.13.0
indexer/chart/Chart.yaml     appVersion 2.12.3 -> 2.13.0
processor-chart/Chart.yaml   appVersion 2.12.3 -> 2.13.0
```

`package-lock.json` is included so it does not drift from `package.json`. The bump target does not update it today; that is tracked separately rather than changed as part of a release.

Chart `version` fields are deliberately untouched: only the chart READMEs changed since v2.12.3, so there is no packaged-behaviour change to signal.

## After merge

Tag `v2.13.0` and create the release; `publish_container_images.yml` fires on `release: published` and pushes to `ghcr.io/threefoldtech/tfchain_graphql_{processor,query-node}` following #226, which is what the charts and compose file already pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YKJm3zuWdSepriT9KL9zy